### PR TITLE
Update gloomrot.md BepInEx and nuget versions

### DIFF
--- a/dev/gloomrot.md
+++ b/dev/gloomrot.md
@@ -3,12 +3,11 @@ title: Gloomrot Migration Guide
 parent: For Developers
 ---
 
-### BepInEx **EXPERIMENTAL** [0.668.001](https://github.com/decaprime/VRising-Modding/releases/tag/0.668.001) 
+### BepInEx **EXPERIMENTAL** [1.668.2](https://github.com/decaprime/VRising-Modding/releases/tag/1.668.2) 
 Please don't distribute this, it's not final nor the way we want to distribute BepInEx.
-This does NOT have the VCRedist in it, so if you dont already have it, get it from microsoft here https://aka.ms/vs/17/release/vc_redist.x64.exe
 
 
-### Game Libs: [nuget](https://www.nuget.org/packages/VRising.Unhollowed.Client/0.6.0.571080001)
+### Game Libs: [nuget](https://www.nuget.org/packages/VRising.Unhollowed.Client/)
 Initial version is not the *correct* way, just unblocking builds. Notice this privately packages the interop changes from above with the already interop'd client assemblies. This avoids the need for the MSBuild task creating the interop and is intended to get developers rolling on release date. 
 
 Versioning on nuget is now game version+zero padded 4 digit version to clarify updates between game versions.
@@ -22,7 +21,7 @@ Versioning on nuget is now game version+zero padded 4 digit version to clarify u
 
 <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
 <PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
-<PackageReference Include="VRising.Unhollowed.Client" Version="0.6.0.57108*" />
+<PackageReference Include="VRising.Unhollowed.Client" Version="0.6.5.*" />
 
 ```
 


### PR DESCRIPTION
Also removed VCRedist warning since it is no longer required.