### PR TITLE
Fixed Incorrect link for the thunderstore

### DIFF
--- a/user/index.md
+++ b/user/index.md
@@ -5,6 +5,6 @@ title: For Users
 
 # For users of mods
 This wiki is currently more intended for developers, but here is some FAQ:
-- V Rising mods at Thunderstore: [https://v-rising.thunderstore.io/]()
+- V Rising mods at Thunderstore: [https://v-rising.thunderstore.io/](https://v-rising.thunderstore.io/)
 - Discord: [V Rising Mod Community Discord](https://vrisingmods.com/discord)
 - Support: Check out support channels in the discord or in the mod's readme


### PR DESCRIPTION
It would just link back to the wiki page instead of taking the user to the thunderstore