### PR TITLE
Wetstone -> Bloodstone Hidden Page

### DIFF
--- a/dev/bloodstone.md
+++ b/dev/bloodstone.md
@@ -1,6 +1,8 @@
 ---
 title: Wetstone -> Bloodstone
 parent: For Developers
+nav_exclude: true
+has_toc: false
 ---
 
 ![bloodstone-banner](https://i.imgur.com/Py0MwUL.png)

--- a/dev/gloomrot.md
+++ b/dev/gloomrot.md
@@ -2,6 +2,7 @@
 title: Migration Guide for Gloomrot
 parent: For Developers
 nav_exclude: true
+has_toc: false
 ---
 
 # Migrating plugins for glooomrot


### PR DESCRIPTION
Wetstone to Bloodstone isn't a relevant topic anymore. I'm suggesting we make it nav excluded and hidden from the table of contents. That way if someone does ask about porting a really old mod that uses Wetstone, the link still exists to prompt on Discord. 