### PR TITLE
Update Theme to 0.10.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ plugins:
 - jekyll-include-cache
 
 
-remote_theme: just-the-docs/just-the-docs@v0.8.2
+remote_theme: just-the-docs/just-the-docs@v0.10.0
 color_scheme: vampire
 
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d8fc8593-7de5-4660-9bf5-8500966dccae)

Currently if you try and put a parent/child structure inside a parent/child structure the table of contents and nav bar drops downs will break.

Updating the theme to 0.10.0 fixes this. 

You can see the site live with the updated version here
https://vrising.wiki/